### PR TITLE
Bump to v1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,3 @@
+# Changelog
+
+Please view our Changelog [here](https://github.com/LifeSG/react-icons/wiki/Changelog)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@lifesg/react-icons",
-    "version": "1.0.0-alpha.1",
+    "version": "1.0.0",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "@lifesg/react-icons",
-            "version": "1.0.0-alpha.1",
+            "version": "1.0.0",
             "license": "ISC",
             "devDependencies": {
                 "@babel/core": "^7.17.8",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@lifesg/react-icons",
-    "version": "1.0.0-alpha.1",
+    "version": "1.0.0",
     "description": "An icon component library for LifeSG and BookingSG web apps",
     "main": "dist/cjs/index.js",
     "module": "dist/index.js",


### PR DESCRIPTION
**Changes**
Previously when we did a test on the pipeline, we published v1.0.0-alpha.1. Even though I already deleted the package, npm still throws an error saying the version is published. Nonetheless, our ideal is v1 anyway. No harm bumping it up. 

-   [delete] branch
